### PR TITLE
#3: Janus monitoring with automatic instance replacement

### DIFF
--- a/cloudformation/cloudcam.yml
+++ b/cloudformation/cloudcam.yml
@@ -462,6 +462,13 @@ Resources:
                   - lightsail:DeleteInstance
                   - lightsail:OpenInstancePublicPorts
                   - route53:ChangeResourceRecordSets
+                  - route53:ListHealthChecks
+                  - route53:CreateHealthCheck
+                  - route53:DeleteHealthCheck
+                  - route53:ChangeTagsForResource
+                  - route53:TestDNSAnswer
+                  - cloudwatch:PutMetricAlarm
+                  - cloudwatch:DeleteAlarms
                   - kms:Decrypt
                 Resource: '*'
               - Effect: Allow
@@ -486,6 +493,7 @@ Resources:
           JANUS_HOSTED_ZONE_ID: !Ref JanusHostedZoneId
           JANUS_HOSTED_ZONE_DOMAIN: !Ref JanusHostedZoneDomain
           JANUS_INSTANCE_NAME_PREFIX: !Ref JanusInstanceNamePrefix
+
   JanusKmsKey:
     Type: AWS::KMS::Key
     Properties:

--- a/cloudformation/deploy-stack.sh
+++ b/cloudformation/deploy-stack.sh
@@ -4,11 +4,30 @@ STACK_NAME=cloudcamdev            # stack name
 S3_CODE_BUCKET=cloudcam-code      # s3 bucket to upload lambda code to, will be created if doesn't exist
 S3_UI_BUCKET=beta.cloudcam.space  # ui bucket
 JANUS_KMS_KEY_USER=cloudcam-ops   # user which is granted permission to encrypt Janus SSL key via encrypt-ssl-key.sh
+JANUS_HEALTH_CHECK_ALARMS_TOPIC=JanusHealthCheckAlarms   # topic for janus gateway health check alarms
 
+AWS_REGION=`aws configure get region`
+AWS_ACCOUNT_ID=`aws sts get-caller-identity --output text --query 'Account'`
+
+# note: Route53 health check notifications require that the Cloudwatch alarm and SNS topic reside in the us-east-1 region
+#       since multi-region cloudformation templates are complicated, we create them using the aws cli here
+JANUS_HEALTH_CHECK_ALARMS_TOPIC_ARN=`aws sns create-topic --region us-east-1 --name ${JANUS_HEALTH_CHECK_ALARMS_TOPIC} --output text`
+JANUS_HEALTH_CHECK_ALARMS_ENDPOINT_ARN=arn:aws:lambda:${AWS_REGION}:${AWS_ACCOUNT_ID}:function:janus_scale_lightsail
+
+# ensure S3_CODE_BUCKET exists
 aws s3 mb s3://${S3_CODE_BUCKET}
+
+# package and deploy the stack
 aws cloudformation package --template-file cloudcam.yml --s3-bucket ${S3_CODE_BUCKET} --output-template-file cloudcam-packaged.yml
 aws cloudformation deploy --template-file cloudcam-packaged.yml \
     --stack-name ${STACK_NAME} --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
     --parameter-overrides JanusKmsKeyUser=${JANUS_KMS_KEY_USER}
+
+# add an SNS subscription for Janus gateway Route53 health checks (see above on why is this not a part of the Cloudformation stack)
+aws sns subscribe --region us-east-1 --topic-arn ${JANUS_HEALTH_CHECK_ALARMS_TOPIC_ARN} --protocol lambda \
+    --notification-endpoint ${JANUS_HEALTH_CHECK_ALARMS_ENDPOINT_ARN} --output text
+
+# upload UI assets to S3_UI_BUCKET
 ( cd ../dev-ui && NODE_ENV=production webpack )
 aws s3 cp --recursive --acl public-read ../dev-ui/webroot s3://${S3_UI_BUCKET}
+


### PR DESCRIPTION
Monitoring is via Route53 health checks (and consequently CloudWatch/SNS/Lambda). Somewhat more complicated than initially imagined since there's need to setup CloudWatch and SNS resources in us-east-1 and then do a cross-region lambda call to a primary region (us-west-2) due to Route53's inability to send metrics to anywhere other than us-east-1 where it lives