### PR TITLE
Deploy scripts maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: python
 python:
 - '3.6'
 script:
-- aws cloudformation validate-template --template-body file://$CF_TEMPLATE
+- if [ ! -z `aws configure get aws_access_key_id` ]; then aws cloudformation validate-template --template-body file://$CF_TEMPLATE; fi
 - yamllint -c .yamllint $CF_TEMPLATE
 install:
 - pip install --upgrade awscli yamllint

--- a/cloudformation/cloudcam.yml
+++ b/cloudformation/cloudcam.yml
@@ -512,7 +512,7 @@ Resources:
             Resource: '*'
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:user/${JanusKmsKeyUser}'
+              AWS: !Sub '${JanusKmsKeyUserArn}'
             Action:
               - kms:Encrypt
             Resource: '*'
@@ -533,7 +533,6 @@ Parameters:
   UiBucketName:
     Type: String
     Description: 'S3 UI bucket name. Must be the same as the UI domain name for CNAME redirect to work'
-    Default: beta.cloudcam.space
   JanusCertPem:
     Type: String
     Description: 'Janus gateway SSL cert PEM'
@@ -561,19 +560,16 @@ Parameters:
   JanusHostedZoneId:
     Type: String
     Description: 'AWS Hosted Zone Id where Janus instances will receive DNS names'
-    Default: Z1MUZ3ZP15MONF
   JanusHostedZoneDomain:
     Type: String
     Description: 'AWS Hosted Zone domain where Janus instances will receive DNS names'
-    Default: cloudcam.space
   JanusInstanceNamePrefix:
     Type: String
     Description: 'Janus instance/dns name prefix'
     Default: ls-janus
-  JanusKmsKeyUser:
+  JanusKmsKeyUserArn:
     Type: String
-    Description: 'User name to grant rights to use Janus SSL KMS key for signing'
-    Default: cloudcam-ops
+    Description: 'ARN of the user to grant rights to use Janus SSL KMS key for signing'
 
 Outputs:
   IdentityPoolId:

--- a/cloudformation/cloudcam.yml
+++ b/cloudformation/cloudcam.yml
@@ -533,14 +533,6 @@ Parameters:
   UiBucketName:
     Type: String
     Description: 'S3 UI bucket name. Must be the same as the UI domain name for CNAME redirect to work'
-  JanusCertPem:
-    Type: String
-    Description: 'Janus gateway SSL cert PEM'
-    Default: ''
-  JanusCertKey:
-    Type: String
-    Description: 'Janus gateway SSL cert KEY'
-    Default: ''
   LightsailAzs:
     Type: String
     Description: 'Lightsail Janus gateway instance availability zone'

--- a/cloudformation/deploy-stack-dev.sh
+++ b/cloudformation/deploy-stack-dev.sh
@@ -4,7 +4,8 @@ STACK_NAME=cloudcamdev            # stack name
 S3_CODE_BUCKET=cloudcam-code      # s3 bucket to upload lambda code to, will be created if doesn't exist
 S3_UI_BUCKET=beta.cloudcam.space  # ui bucket
 CLOUDFRONT_UI_DISTRIBUTION_ID=E3RT8HOQAAG0IG   # ui cloudfront distribution id
-JANUS_KMS_KEY_USER=cloudcam-ops   # user which is granted permission to encrypt Janus SSL key via encrypt-ssl-key.sh
+JANUS_HOSTED_ZONE_ID=Z1MUZ3ZP15MONF            # aws hosted zone id where janus instances will receive dns names
+JANUS_HOSTED_ZONE_DOMAIN=cloudcam.space        # aws hosted zone domain where janus instances will receive dns names
 JANUS_HEALTH_CHECK_ALARMS_TOPIC=JanusHealthCheckAlarms   # topic for janus gateway health check alarms
 
 source deploy-stack.sh

--- a/cloudformation/deploy-stack-travis.sh
+++ b/cloudformation/deploy-stack-travis.sh
@@ -12,7 +12,8 @@ configure_dev() {
   STACK_NAME=cloudcam-dev               # stack name
   S3_CODE_BUCKET=cloudcam-cf-dev        # s3 bucket to upload lambda code to, will be created if doesn't exist
   S3_UI_BUCKET=ccdev.mvstg.biz          # ui bucket
-  JANUS_KMS_KEY_USER=cloudcam-ops-dev   # user which is granted permission to encrypt Janus SSL key via encrypt-ssl-key.sh
+  JANUS_HOSTED_ZONE_ID=Z1MUZ3ZP15MONF            # aws hosted zone id where janus instances will receive dns names
+  JANUS_HOSTED_ZONE_DOMAIN=cloudcam.space        # aws hosted zone domain where janus instances will receive dns names
   JANUS_HEALTH_CHECK_ALARMS_TOPIC=JanusHealthCheckAlarms-Dev   # topic for janus gateway health check alarms
   # CLOUDFRONT_UI_DISTRIBUTION_ID=EXXXXXXX   # ui cloudfront distribution id
 }

--- a/cloudformation/deploy-stack.sh
+++ b/cloudformation/deploy-stack.sh
@@ -3,6 +3,12 @@
 # SET CONFIG VARS FIRST before calling this script
 # (see deploy-stack-dev.sh)
 
+# check if aws_access_key_id is present so we can continue, otherwise terminate without error
+if [[ -z `aws configure get aws_access_key_id` ]]; then
+  echo Missing aws_access_key_id; skipping the deployment
+  exit
+fi
+
 # try to find aws region and account id
 if [[ -n "$AWS_DEFAULT_REGION" ]]; then
   AWS_REGION="${AWS_REGION:-$AWS_DEFAULT_REGION}"

--- a/cloudformation/deploy-stack.sh
+++ b/cloudformation/deploy-stack.sh
@@ -13,10 +13,13 @@ fi
 if [[ -z "$AWS_ACCOUNT_ID" ]]; then
   AWS_ACCOUNT_ID=`aws sts get-caller-identity --output text --query 'Account'`
 fi
+if [[ -z "$JANUS_KMS_KEY_USER_ARN" ]]; then
+  JANUS_KMS_KEY_USER_ARN=`aws sts get-caller-identity --output text --query 'Arn'`
+fi
 
 # sanity-check for presence of required configuration variables
 MISSING=
-for config in STACK_NAME S3_CODE_BUCKET AWS_REGION JANUS_KMS_KEY_USER JANUS_HEALTH_CHECK_ALARMS_TOPIC AWS_ACCOUNT_ID; do
+for config in STACK_NAME S3_CODE_BUCKET AWS_REGION JANUS_KMS_KEY_USER_ARN JANUS_HOSTED_ZONE_ID JANUS_HOSTED_ZONE_DOMAIN JANUS_HEALTH_CHECK_ALARMS_TOPIC AWS_ACCOUNT_ID; do
   if [[ -z "${!config}" ]]; then
     echo "ERROR: missing configuration variable: $config"
     MISSING=1
@@ -37,10 +40,13 @@ JANUS_HEALTH_CHECK_ALARMS_ENDPOINT_ARN=arn:aws:lambda:${AWS_REGION}:${AWS_ACCOUN
 aws s3 mb s3://${S3_CODE_BUCKET}
 
 # package and deploy the stack
-aws cloudformation package --template-file cloudcam.yml --s3-bucket ${S3_CODE_BUCKET} --output-template-file DIR/cloudcam-packaged.yml
+aws cloudformation package --template-file cloudcam.yml --s3-bucket ${S3_CODE_BUCKET} --output-template-file $DIR/cloudcam-packaged.yml
 aws cloudformation deploy --template-file $DIR/cloudcam-packaged.yml \
     --stack-name ${STACK_NAME} --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
-    --parameter-overrides JanusKmsKeyUser=${JANUS_KMS_KEY_USER}
+    --parameter-overrides UiBucketName=${S3_UI_BUCKET} JanusKmsKeyUserArn=${JANUS_KMS_KEY_USER_ARN} \
+    JanusHostedZoneId=${JANUS_HOSTED_ZONE_ID} JanusHostedZoneDomain=${JANUS_HOSTED_ZONE_DOMAIN}
+
+echo UI URL: $(aws cloudformation describe-stacks --stack-name ${STACK_NAME} --query 'Stacks[0].Outputs[?OutputKey==`UiUrl`].OutputValue' --output text)
 
 # add an SNS subscription for Janus gateway Route53 health checks (see above on why is this not a part of the Cloudformation stack)
 aws sns subscribe --region us-east-1 --topic-arn ${JANUS_HEALTH_CHECK_ALARMS_TOPIC_ARN} --protocol lambda \
@@ -49,8 +55,8 @@ aws sns subscribe --region us-east-1 --topic-arn ${JANUS_HEALTH_CHECK_ALARMS_TOP
 # upload UI
 if [[ -n "$S3_UI_BUCKET" ]]; then
   # upload UI assets to S3_UI_BUCKET
-  ( cd ../dev-ui && NODE_ENV=production webpack )
-  aws s3 cp --recursive --acl public-read $DEV/../dev-ui/webroot s3://${S3_UI_BUCKET}
+  ( cd ../dev-ui && NODE_ENV=production webpack > /dev/null )
+  aws s3 cp --recursive --acl public-read $DIR/../dev-ui/webroot s3://${S3_UI_BUCKET}
   # invalidate cloudfront
   if [[ -n "$CLOUDFRONT_UI_DISTRIBUTION_ID" ]]; then
     aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_UI_DISTRIBUTION_ID} --paths '/*'


### PR DESCRIPTION
1. Replace JanusKmsKeyUser with JanusKmsKeyUserArn and make it default to the user creating/updating the stack (default value makes sense if dev/deploy roles are identical, might be good idea to set to dev role arn if distinct)
2. Make JANUS_HOSTED_ZONE_ID and JANUS_HOSTED_ZONE_DOMAIN parameters non-optional (since obviously Janus domain and zone id are different for different deployments)